### PR TITLE
🏷️ Type > Event

### DIFF
--- a/client/src/types/Event/index.d.ts
+++ b/client/src/types/Event/index.d.ts
@@ -1,0 +1,13 @@
+export declare interface InputEvent {
+  target: HTMLInputElement;
+}
+
+declare global {
+  interface ChangeEvent<T extends EventTarget = HTMLElement> extends Event {
+    target: T;
+  }
+
+  interface ClickEvent<T extends EventTarget = HTMLElement> extends Event {
+    target: T;
+  }
+}


### PR DESCRIPTION
### issue
close #68

### 내용
`addEventListener('click' , (e: ClickEvent<HtmlButtonElement>) => {})`
이렇게 해서 e.target 타입을 유추하는 방법입니다.